### PR TITLE
Move extractId from SlickJdbcDao to SlickDao

### DIFF
--- a/src/main/scala/slick/dao/SlickDao.scala
+++ b/src/main/scala/slick/dao/SlickDao.scala
@@ -19,6 +19,13 @@ package slick.dao
 
 trait SlickDao[M, I] {
 
+  /**
+   * Extracts the model Id of a arbitrary model.
+   * @param model a mapped model
+   * @return an Some[I] if Id is filled, None otherwise
+   */
+  def extractId(model: M): Option[I]
+
   def count: Int
   def save(model: M): M
 

--- a/src/main/scala/slick/dao/SlickJdbcDao.scala
+++ b/src/main/scala/slick/dao/SlickJdbcDao.scala
@@ -36,13 +36,6 @@ trait SlickJdbcDao[M, I] extends SlickDao[M, I] {
 
 
   /**
-   * Extracts the model Id of a arbitrary database model.
-   * @param model a mapped model
-   * @return an Some[I] if Id is filled, None otherwise
-   */
-  def extractId(model: M): Option[I]
-
-  /**
    *
    * @param model a mapped model (usually without an assigned id).
    * @param id an id, usually generate by the database


### PR DESCRIPTION
Hello Renato,

Here is a second PR; it's really simple: move extractId in the generic SlickDao interface.

This is something not really jdbc related nor SlickJdbcDao specific.
It can be used to build more specific dao.
It can be used in tests where you implement a SlickDao to mock a SlickJdbcDao.
