### PR TITLE
Fix example trait used for MappingActiveSlickIdentifiable

### DIFF
--- a/modules/samples/src/main/scala/io/strongtyped/active/slick/docexamples/MappingActiveSlickIdentifiable.scala
+++ b/modules/samples/src/main/scala/io/strongtyped/active/slick/docexamples/MappingActiveSlickIdentifiable.scala
@@ -27,7 +27,7 @@ trait MappingActiveSlickIdentifiable {
 
 object MappingActiveSlickIdentifiableApp {
 
-  class Components(override val jdbcDriver: JdbcDriver) extends ActiveSlick with MappingWithActiveSlick {
+  class Components(override val jdbcDriver: JdbcDriver) extends ActiveSlick with MappingActiveSlickIdentifiable {
     import jdbcDriver.simple._
     val db = Database.forURL("jdbc:h2:mem:active-slick", driver = "org.h2.Driver")
     def createSchema(implicit sess: Session) = Foos.ddl.create


### PR DESCRIPTION
This example's App actually used the other example's trait instead of it's own