### PR TITLE
simplify JdbcProfileProvider by removing "type JP" from base trait

### DIFF
--- a/modules/core/src/main/scala/io/strongtyped/active/slick/JdbcProfileProvider.scala
+++ b/modules/core/src/main/scala/io/strongtyped/active/slick/JdbcProfileProvider.scala
@@ -4,40 +4,32 @@ import slick.driver.{DerbyDriver, SQLiteDriver, MySQLDriver, HsqldbDriver, Postg
 
 
 trait JdbcProfileProvider {
-  type JP <: JdbcProfile
-  val jdbcProfile: JP
+  val jdbcProfile: JdbcProfile
 }
 
 object JdbcProfileProvider {
 
   trait H2ProfileProvider extends JdbcProfileProvider {
-    type JP = H2Driver
     val jdbcProfile: H2Driver = H2Driver
   }
 
   trait PostgresProfileProvider extends JdbcProfileProvider {
-    type JP = PostgresDriver
     val jdbcProfile = PostgresDriver
   }
 
-
   trait DerbyProfileProvider extends JdbcProfileProvider {
-    type JP = DerbyDriver
     val jdbcProfile = DerbyDriver
   }
 
   trait HsqlProfileProvider extends JdbcProfileProvider {
-    type JP = HsqldbDriver
     val jdbcProfile = HsqldbDriver
   }
 
   trait MySQLProfileProvider extends JdbcProfileProvider {
-    type JP = MySQLDriver
     val jdbcProfile = MySQLDriver
   }
 
   trait SQLLiteProfileProvider extends JdbcProfileProvider {
-    type JP = SQLiteDriver
     val jdbcProfile = SQLiteDriver
   }
 

--- a/modules/samples/src/main/scala/io/strongtyped/active/slick/docexamples/ActiveSlickWithCodegen.scala
+++ b/modules/samples/src/main/scala/io/strongtyped/active/slick/docexamples/ActiveSlickWithCodegen.scala
@@ -15,7 +15,6 @@ object ActiveSlickWithCodegen {
     //
     // Implement JdbcProfileProvider with JDBCProfile from generated Tables.scala
     //
-    override type JP = Tables.profile.type
     // Sucks that this is necessary. Did we have to define this type in JdbcProfileProvider? Why not just use JdbcProfile?
     override val jdbcProfile = Tables.profile
 


### PR DESCRIPTION
Removing the type declaration from JdbcProfileProvider simplifies mixing in the JdbcProfileProvider trait.  After the change ActiveSlickWithCodegen no longer has to override the type definition.