### PR TITLE
Fix compile error when import a different driver.

### DIFF
--- a/modules/core/src/main/scala/io/strongtyped/active/slick/EntityActions.scala
+++ b/modules/core/src/main/scala/io/strongtyped/active/slick/EntityActions.scala
@@ -4,6 +4,7 @@ import io.strongtyped.active.slick.DBIOExtensions._
 import io.strongtyped.active.slick.exceptions.{NoRowsAffectedException, RowNotFoundException}
 import slick.ast.BaseTypedType
 import slick.dbio.{FailureAction, SuccessAction}
+import slick.profile.RelationalProfile
 
 import scala.concurrent.ExecutionContext
 import scala.language.{existentials, higherKinds, implicitConversions}
@@ -18,7 +19,7 @@ abstract class EntityActions extends EntityActionsLike {
 
   protected implicit lazy val btt: BaseTypedType[Id] = baseTypedType
 
-  type EntityTable <: Table[Entity]
+  type EntityTable <: RelationalProfile#Table[Entity]
 
   def tableQuery: TableQuery[EntityTable]
 


### PR DESCRIPTION
When I use play-slick with slick. If I define a table out of the dao class, I need to import a different `driver.api._` to create the EntityTable. And If the `EntityActions` use `driver.Table` it will compile fail. So this pr use `RelationalProfile#Table`, hope for fix it. ( like https://github.com/slick/slick/pull/1281 , and the issue is https://github.com/slick/slick/issues/1253 )