### PR TITLE
Build against Scala 2.13.x

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -9,7 +9,7 @@ ivyScala := ivyScala.value map {
 
 organization in ThisBuild := "io.strongtyped"
 
-crossScalaVersions in ThisBuild := Seq("2.11.11", "2.12.2")
+crossScalaVersions in ThisBuild := Seq("2.11.12", "2.12.16", "2.13.8")
 
 parallelExecution in Test := false
 

--- a/modules/core/src/test/scala/io/strongtyped/active/slick/BeerTest.scala
+++ b/modules/core/src/test/scala/io/strongtyped/active/slick/BeerTest.scala
@@ -3,10 +3,11 @@ package io.strongtyped.active.slick
 import io.strongtyped.active.slick.exceptions.RowNotFoundException
 import io.strongtyped.active.slick.test.H2Suite
 import org.scalatest._
+import org.scalatest.flatspec.AnyFlatSpec
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.language.postfixOps
 
-class BeerTest extends FlatSpec with H2Suite with Schema {
+class BeerTest extends AnyFlatSpec with H2Suite with Schema {
 
   behavior of "A Beer"
 

--- a/modules/core/src/test/scala/io/strongtyped/active/slick/CrudTest.scala
+++ b/modules/core/src/test/scala/io/strongtyped/active/slick/CrudTest.scala
@@ -1,13 +1,13 @@
 package io.strongtyped.active.slick
 
 import io.strongtyped.active.slick.test.H2Suite
-import org.scalatest.FlatSpec
 import slick.ast.BaseTypedType
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.language.postfixOps
 import io.strongtyped.active.slick.Lens._
+import org.scalatest.flatspec.AnyFlatSpec
 
-class CrudTest extends FlatSpec with H2Suite with JdbcProfileProvider {
+class CrudTest extends AnyFlatSpec with H2Suite with JdbcProfileProvider {
 
   behavior of "An EntityDao (CRUD)"
 

--- a/modules/core/src/test/scala/io/strongtyped/active/slick/EntityActionsBeforeInsertUpdateTest.scala
+++ b/modules/core/src/test/scala/io/strongtyped/active/slick/EntityActionsBeforeInsertUpdateTest.scala
@@ -1,13 +1,13 @@
 package io.strongtyped.active.slick
 
 import io.strongtyped.active.slick.test.H2Suite
-import org.scalatest.FlatSpec
 import slick.ast.BaseTypedType
 import io.strongtyped.active.slick.Lens._
 import scala.concurrent.ExecutionContext
+import org.scalatest.flatspec.AnyFlatSpec
 
 class EntityActionsBeforeInsertUpdateTest
-  extends FlatSpec with H2Suite with JdbcProfileProvider {
+  extends AnyFlatSpec with H2Suite with JdbcProfileProvider {
 
   behavior of "An EntityDao with validation "
 

--- a/modules/core/src/test/scala/io/strongtyped/active/slick/SupplierTest.scala
+++ b/modules/core/src/test/scala/io/strongtyped/active/slick/SupplierTest.scala
@@ -5,9 +5,10 @@ import scala.concurrent.ExecutionContext.Implicits.global
 import io.strongtyped.active.slick.exceptions.StaleObjectStateException
 import io.strongtyped.active.slick.test.H2Suite
 import org.scalatest._
+import org.scalatest.flatspec.AnyFlatSpec
 import slick.dbio.DBIO
 
-class SupplierTest extends FlatSpec with H2Suite with Schema {
+class SupplierTest extends AnyFlatSpec with H2Suite with Schema {
 
   behavior of "A Supplier"
 

--- a/modules/core/src/test/scala/io/strongtyped/active/slick/test/DbSuite.scala
+++ b/modules/core/src/test/scala/io/strongtyped/active/slick/test/DbSuite.scala
@@ -2,6 +2,7 @@ package io.strongtyped.active.slick.test
 
 import io.strongtyped.active.slick.JdbcProfileProvider
 import org.scalatest._
+import org.scalatest.matchers.should.Matchers
 import slick.basic.DatabasePublisher
 
 import scala.concurrent.duration.{FiniteDuration, _}

--- a/modules/samples/src/test/scala/io/strongtyped/active/slick/docexamples/ActiveSlickWithCodegenTest.scala
+++ b/modules/samples/src/test/scala/io/strongtyped/active/slick/docexamples/ActiveSlickWithCodegenTest.scala
@@ -4,12 +4,13 @@ import io.strongtyped.active.slick.docexamples.ActiveSlickWithCodegen.ComputersR
 import io.strongtyped.active.slick.docexamples.ActiveSlickWithCodegen.ComputersRepo.EntryExtensions
 import io.strongtyped.active.slick.test.H2Suite
 import org.scalatest._
+import org.scalatest.flatspec.AnyFlatSpec
 import ComputersRepo.EntryExtensions
 import io.strongtyped.active.slick.docexamples.codegen.Tables.ComputersRow
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.language.postfixOps
 
-class ActiveSlickWithCodegenTest extends FlatSpec with H2Suite with OptionValues {
+class ActiveSlickWithCodegenTest extends AnyFlatSpec with H2Suite with OptionValues {
 
   "ActiveSlickWithCodegen" should "provide crud and active record semantics for generated tables" in {
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -2,10 +2,10 @@ import sbt.Keys._
 import sbt._
 
 object Dependencies {
-  val slickVersion = "3.2.0"
+  val slickVersion = "3.3.3"
   val slick = "com.typesafe.slick" %% "slick" % slickVersion
 
-  val shapelessDeps = Seq("com.chuusai" %% "shapeless" % "2.3.2")
+  val shapelessDeps = Seq("com.chuusai" %% "shapeless" % "2.3.3")
   /*Def setting (
     CrossVersion partialVersion scalaVersion.value match {
       case Some((2, scalaMajor)) if scalaMajor >= 11 =>
@@ -19,7 +19,7 @@ object Dependencies {
   )*/
 
 
-  val scalaTest = "org.scalatest" %% "scalatest" % "3.0.1" % "test"
+  val scalaTest = "org.scalatest" %% "scalatest" % "3.2.13" % "test"
   val h2database = "com.h2database" % "h2" % "1.4.181" % "test"
 
   val mainDeps = Seq(

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.8
+sbt.version=0.13.18


### PR DESCRIPTION
Bump some versions:
- Build against Scala `2.12.16` and `2.11.12`, and add support for `2.13.8`
- Bump SBT version to `0.13.18` to fix jline crash on load 
- Bump ScalaTest, Slick, and Shapeless versions to support `2.13.x`
  - Change some ScalaTest imports due to organizational changes from ScalaTest 3.0.x -> 3.2.x
 
Everything compiles, though with some warnings in some cases.

All unit tests pass for all Scala versions.